### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_gh-pages.yml
+++ b/.github/workflows/deploy_gh-pages.yml
@@ -47,6 +47,8 @@ jobs:
   build:
     name: MkDocs Github Pages automatic deployment
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: 
       - linters 
       - scan_semgrep


### PR DESCRIPTION
Potential fix for [https://github.com/antoniohernan/pruebadeconcepto/security/code-scanning/3](https://github.com/antoniohernan/pruebadeconcepto/security/code-scanning/3)

In general, the fix is to explicitly declare the minimal required GITHUB_TOKEN permissions instead of relying on inherited defaults. For this workflow, the `build` job needs to push documentation to the `gh-pages` branch via `mkdocs gh-deploy`, which uses Git under the hood, so it requires `contents: write`. We should therefore add a `permissions` block to the `build` job, parallel to the ones already present for `scan_gitleaks` and `scan_semgrep`.

Concretely: in `.github/workflows/deploy_gh-pages.yml`, under `jobs:`, locate the `build:` job (line 47 onward). Add a `permissions:` section immediately under `build:` (or directly under `name:`) with `contents: write`. This leaves all steps and behavior untouched while constraining GITHUB_TOKEN to only repository contents write access for this job, satisfying the least-privilege recommendation and silencing the CodeQL warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
