### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repolint.yml
+++ b/.github/workflows/repolint.yml
@@ -9,6 +9,8 @@ on:
       
 jobs:
   launch-repolint:
+    permissions:
+      contents: read
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}                                    # Only 1 instance at time 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/antoniohernan/pruebadeconcepto/security/code-scanning/1](https://github.com/antoniohernan/pruebadeconcepto/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow so the `GITHUB_TOKEN` used by this job is limited to the minimal scopes it needs. For this repolinter workflow, the steps only read repository contents (via `actions/checkout`) and run local tooling; they do not interact with issues, pull requests, or perform any write operations. Therefore, `contents: read` at the job (or workflow) level is sufficient and does not change existing behavior, while preventing unintended write access if defaults are permissive.

The best, least-disruptive fix is to add a `permissions` section to the `launch-repolint` job. This keeps the change tightly scoped to this workflow and documents the intended access. Concretely, in `.github/workflows/repolint.yml`, under `jobs: launch-repolint:` and before `concurrency:` (currently line 12), add:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed, since this is purely a YAML configuration change within the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
